### PR TITLE
ci: release workflow triggered by pre-release versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Validate & Release
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+.*
 jobs:
   validate:
     uses: ./.github/workflows/run-validation.yml


### PR DESCRIPTION
# Summary
Currently, pre-release versions to not trigger the release workflow.
This change updates the workflow to match either a standard release version (eg, `v0.0.0`) as well as a version tag including content after the standard release version( eg, a pre-release version: `v0.0.0-rc.0`)
